### PR TITLE
java8 can't compile GNU Prolog for Java

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -86,10 +86,13 @@ Ant Buildfile for GNU Prolog for Java.
 	<target name="compile" depends="init">
 		<mkdir dir="build/code" />
 		<javac srcdir="src" destdir="build/code"
-			includeantruntime="false"
-			classpath="${java.class.path}:/usr/share/java/gnu-getopt.jar"
-			debug="${java.debug}" debuglevel="lines,vars,source"
-			excludes="**/package-info.java" />
+		       includeantruntime="false"
+                       fork="true"
+		       classpath="${java.class.path}:/usr/share/java/gnu-getopt.jar"
+		       debug="${java.debug}" debuglevel="lines,vars,source"
+		       excludes="**/package-info.java" >
+                  <compilerarg value="-J-Xss2M"/>
+                </javac>
 		<copy todir="build/code">
 			<fileset dir="src">
 				<include name="**/*.pro" />


### PR DESCRIPTION
Java 8 (and probably 7) allocate too small a stack to the compiler, resulting in an overflow during compilation. A small patch to build.xml fixes this by bumping the stack to 2MB and directing ant to start compilers in their own JVM. Without this, I cannot compile the package using java8.
