### PR TITLE
If an atom does not start with an atom-start-char then it SHOULD be quoted

### DIFF
--- a/src/gnu/prolog/io/TermWriter.java
+++ b/src/gnu/prolog/io/TermWriter.java
@@ -552,7 +552,7 @@ public class TermWriter extends PrintWriter
 		}
 		else
 		{
-			return false;
+                        return true;
 		}
 	}
 


### PR DESCRIPTION
This was swapped with a977fde6a83f0bf7484d0d53949e5fa65e223961. 

I'm pretty sure that if an atom does not begin with an atom-start-char, then it /has/ to be quoted. As an example, try this:
      System.out.println(gnu.prolog.term.AtomTerm.get("Hello"));
Surely that should print 'Hello' and not Hello. Certainly if you try and read it back, you get a VariableTerm.
