### PR TITLE
When popping a return point from the stack, we must restore the trail pointer

### DIFF
--- a/src/gnu/prolog/vm/Interpreter.java
+++ b/src/gnu/prolog/vm/Interpreter.java
@@ -635,7 +635,8 @@ public final class Interpreter implements HasEnvironment
 			backtrackInfoAmount = rp.rBacktrackInfoAmount;
 			backtrackInfoMax = rp.rBacktrackInfoMax;
 			variables = rp.rVariables;
-			undoData = rp.rUndoData;
+                        variablesAmount = rp.rVariablesAmount;
+                        undoData = rp.rUndoData;
 			undoDataAmount = rp.rUndoDataAmount;
 			undoPositionAsked = rp.rUndoPositionAsked;
 			currentGoal = rp.rCurrentGoal;


### PR DESCRIPTION
This is variablesAmount. Since this points to variables, which is also popped, failing to pop the pointer means we risk writing outside of the bounds of variables - at best we are writing to the wrong part of the array.
