### PR TITLE
Variable token is surely not one single upper-case char

### DIFF
--- a/src/gnu/prolog/io/parser/TermParser.jj
+++ b/src/gnu/prolog/io/parser/TermParser.jj
@@ -855,7 +855,7 @@ TOKEN :
 
 | <#NAMED_VARIABLE
 	: 	  <VARIABLE_INDICATOR_CHAR> (<ID_CONTINUE>)+
-              	| <LU> (<ID_CONTINUE>)					>
+		| <LU> (<ID_CONTINUE>)*					>
               	
 | <#VARIABLE_INDICATOR_CHAR
 	: 	  <UNDERSCORE_CHAR>			/* 6.5.2*/	>


### PR DESCRIPTION
I'm not sure how I left this off my other merge for fixing the parser, but I certainly remember fixing it in my other branch. Without this you'll not get a usable parser from javacc. It looks like this was introduced in ad5bd753
