### PR TITLE
Meta predicate implementation

### DIFF
--- a/docs/manual.texinfo
+++ b/docs/manual.texinfo
@@ -245,14 +245,56 @@ This should then provide support for part 3 of the standard. This currently does
 
 @node Modules
 @subsection Module support in GPJ
-GPJ supports SWI-Prolog-style modules. A single file can define 0..N modules, using the directive :-module/2. The first argument is the name of the module you would like to define, and must be an atom. The second argument is a list of predicate indicators which comprise the exported predicates - those accessible to other modules. By default, code is compiled into the module 'user' - if you never use the :-module/2 directive, this is where all your code will end up.
+GPJ supports SWI-Prolog-style modules. A single file can define 0..N modules, using the directive @code{:-module/2}. The first argument is the name of the module you would like to define, and must be an atom. The second argument is a list of predicate indicators which comprise the exported predicates - those accessible to other modules. By default, code is compiled into the module 'user' - if you never use the @code{:-module/2} directive, this is where all your code will end up.
 
-A meta-predicate :/2 is provided to call code directly in other modules. The first argument is the name of the module, the second is the goal. Doing this changes the value of the current module to the named one, then executes the goal directly.
+A meta-predicate @code{:/2} is provided to call code directly in other modules. The first argument is the name of the module, the second is the goal. Doing this changes the value of the current module to the named one, then executes the goal directly.
 
-When compiling a module, shims are installed in user for exported predicate. Suppose you export foo/3 from your module bar. This will result in the following predicate being created in the user module:
-@code{foo(A,B,C):- bar:foo(A,B,C).}
+When compiling a module, shims are installed in user for exported predicate. Suppose you export @code{foo/3} from your module bar. This will result in the following predicate being created in the user module:
+@example
+foo(A,B,C):- bar:foo(A,B,C).
+@end example
 
-The final element that is required for the module system is the fallback to the user module. If the currently executing code tries to call a predicate which is not defined in the current module, it will not decide that the predicate is undefined until it has further checked the user module. Continuing the example above, that means that if you are executing code in a module qux, and call foo(a,b,c) then - assuming there is not a foo/3 also defined in qux, which would take preference - the foo/3 definition in user would be used. This would call :/2, changing the current module to bar, then call foo/3 again, only this time the definition of the exported predicate would be found and executed. The current module is implemented via a stack, and manages restoring the state on backtrack as well as popping modules off the top once the :/2 goal has completed.
+The final element that is required for the module system is the fallback to the user module. If the currently executing code tries to call a predicate which is not defined in the current module, it will not decide that the predicate is undefined until it has further checked the user module. Continuing the example above, that means that if you are executing code in a module qux, and call @code{foo(a,b,c)} then - assuming there is not a @code{foo/3} also defined in qux, which would take preference - the @code{foo/3} definition in user would be used. This would call @code{:/2}, changing the current module to bar, then call @code{foo/3} again, only this time the definition of the exported predicate would be found and executed. The current module is implemented via a stack, and manages restoring the state on backtrack as well as popping modules off the top once the @code{:/2} goal has completed.
+
+@subsubsection Meta-predicates
+GNU Prolog for Java supports the @code{meta_predicate/1} directive. Code extending ExecuteOnlyMetaCode also explicitly declares information about which arguments are meta- via the @code{getMetaPredicateInfo()} method.
+
+The directive has the format
+@example
+:-meta_predicate(functor(ArgType, ArgType, ...)).
+@end example
+
+The allowed values for ArgType are:
+@itemize @bullet
+@item 0-9 The arg is a meta-argument (the actual number used is currently ignored)
+@item :   The arg is not a goal, but is still module-sensitive
+@item ^   The arg is a possibly existentially quantified goal. This is required for bagof/3 and setof/3
+@item +   The arg is not module sensitive and expected to be bound on call (this is not actually checked)
+@item -   The arg is not module sensitive and expected to be unbound on call (this is not actually checked)
+@item ?   The arg is not module sensitive and no expectation about instantiation is made on call
+@end itemize
+
+Meta-predicate information is required to solve a problem that quickly arises when using modules. A quick example will illustrate it succinctly:
+@example
+:-module(my_module, my_predicate/1).
+my_predicate(Xs):-
+   findall(X, private_predicate(X), Xs).
+
+private_predicate(a).
+private_predicate(b).
+@end example
+
+Note that findall/3 is defined in @code{module(user)}. If we run
+@example
+?- my_predicate(X)
+@end example
+
+then the VM would first switch to @code{module(my_module)} to run @code{my_predicate/1}, then try to resolve @code{findall/3}, which is defined in user. So, we switch back to @code{module(user)} to run @code{findall(X, private_predicate(X), Xs)}, but immediately there is a problem, because when @code{findall/3} tries to execute its second argument, the VM discovers that @code{private_predicate/1} is not resolvable in the current module.
+
+To fix this, @code{findall/3} is declared as a meta-predicate: The first and last args have meta-type @code{?}, and the second arg has meta-type @code{0}. This means that when the VM changes module to run @code{findall/3}, it actually rewrites the goals - in particular, the second goal is rewritten as @code{my_module:private_predicate(X)}. Now when @code{findall/3} is executed, it includes an explicit context-switch back to my_module, and @code{private_predicate/1} is able to be resolved.
+
+
+
 
 @node Contributing
 @chapter Contributing

--- a/src/gnu/prolog/database/MetaPredicateInfo.java
+++ b/src/gnu/prolog/database/MetaPredicateInfo.java
@@ -1,0 +1,86 @@
+/* GNU Prolog for Java
+ * Copyright (C) 2016       Matt Lilley
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA  02111-1307, USA. The text of license can be also found
+ * at http://www.gnu.org/copyleft/lgpl.html
+ */
+package gnu.prolog.database;
+
+import gnu.prolog.vm.PrologException;
+import gnu.prolog.term.Term;
+import gnu.prolog.term.AtomTerm;
+import gnu.prolog.term.IntegerTerm;
+import java.util.HashMap;
+
+/**
+ *  MetaPredicateInfo describes the meta-predicate information for a predicate
+ *  It contains an array, args, of the same size as the arity of the predicate,
+ *  containing MetaType enum values
+ *   NORMAL   indicates that the argument is module-insensitive
+ *   META     indicates that the argument is module-sensitive
+ *   ONE-NINE indicate that the argument is module-sensitive and takes that many extra args when called
+ *   COLON    indicates that the argument is module-sensitive but is not a goal
+ *   EXISTS   indicates that the argument is module-sensitive and may be quantified with the ^ operator
+ */
+
+public class MetaPredicateInfo
+{
+	private static HashMap<Term, MetaType> map = new HashMap<Term, MetaType>();
+
+	static
+	{
+		map.put(AtomTerm.get("+"), MetaType.NORMAL);
+		map.put(AtomTerm.get("-"), MetaType.NORMAL);
+		map.put(AtomTerm.get("*"), MetaType.NORMAL);
+		map.put(AtomTerm.get("?"), MetaType.NORMAL);
+		map.put(AtomTerm.get("//"), MetaType.TWO);
+		map.put(IntegerTerm.get(0), MetaType.META);
+		map.put(IntegerTerm.get(1), MetaType.ONE);
+		map.put(IntegerTerm.get(2), MetaType.TWO);
+		map.put(IntegerTerm.get(3), MetaType.THREE);
+		map.put(IntegerTerm.get(4), MetaType.FOUR);
+		map.put(IntegerTerm.get(5), MetaType.FIVE);
+		map.put(IntegerTerm.get(6), MetaType.SIX);
+		map.put(IntegerTerm.get(7), MetaType.SEVEN);
+		map.put(IntegerTerm.get(8), MetaType.EIGHT);
+		map.put(IntegerTerm.get(9), MetaType.NINE);
+		map.put(AtomTerm.get(":"), MetaType.COLON);
+		map.put(AtomTerm.get("^"), MetaType.EXISTS);
+	}
+
+	public enum MetaType
+	{
+		NORMAL, META, ONE, TWO, THREE, FOUR, FIVE, SIX, SEVEN, EIGHT, NINE, COLON, EXISTS;
+	}
+	public MetaType[] args = null;
+	public MetaPredicateInfo(MetaType[] args)
+	{
+		this.args = args;
+	}
+
+	/**
+	 *  Given a term, retrieve the appropriate meta value for it
+	 * @param t
+	 *   The term to look up
+	 * @throws PrologException
+	 *   if t does not correspond to a meta type
+	 */
+	public static MetaType get(Term t) throws PrologException
+	{
+		if (map.containsKey(t))
+			return map.get(t);
+		PrologException.domainError(AtomTerm.get("meta_argument_specifier"), t);
+		return MetaType.NORMAL; // Unreachable
+	}
+}

--- a/src/gnu/prolog/database/MetaPredicateInfo.java
+++ b/src/gnu/prolog/database/MetaPredicateInfo.java
@@ -1,0 +1,85 @@
+/* GNU Prolog for Java
+ * Copyright (C) 2016       Matt Lilley
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA  02111-1307, USA. The text of license can be also found
+ * at http://www.gnu.org/copyleft/lgpl.html
+ */
+package gnu.prolog.database;
+
+import gnu.prolog.vm.PrologException;
+import gnu.prolog.term.Term;
+import gnu.prolog.term.AtomTerm;
+import gnu.prolog.term.IntegerTerm;
+import java.util.HashMap;
+
+/**
+ *  MetaPredicateInfo describes the meta-predicate information for a predicate
+ *  It contains an array, args, of the same size as the arity of the predicate,
+ *  containing MetaType enum values
+ *   NORMAL   indicates that the argument is module-insensitive
+ *   META     indicates that the argument is module-sensitive
+ *   ONE-NINE indicate that the argument is module-sensitive and takes that many extra args when called
+ *   COLON    indicates that the argument is module-sensitive but is not a goal
+ *   EXISTS   indicates that the argument is module-sensitive and may be quantified with the ^ operator
+ */
+
+public class MetaPredicateInfo
+{
+	private static HashMap<Term, MetaType> map = new HashMap<Term, MetaType>();
+
+	static
+	{
+		map.put(AtomTerm.get("+"), MetaType.NORMAL);
+		map.put(AtomTerm.get("-"), MetaType.NORMAL);
+		map.put(AtomTerm.get("*"), MetaType.NORMAL);
+		map.put(AtomTerm.get("//"), MetaType.TWO);
+		map.put(IntegerTerm.get(0), MetaType.META);
+		map.put(IntegerTerm.get(1), MetaType.ONE);
+		map.put(IntegerTerm.get(2), MetaType.TWO);
+		map.put(IntegerTerm.get(3), MetaType.THREE);
+		map.put(IntegerTerm.get(4), MetaType.FOUR);
+		map.put(IntegerTerm.get(5), MetaType.FIVE);
+		map.put(IntegerTerm.get(6), MetaType.SIX);
+		map.put(IntegerTerm.get(7), MetaType.SEVEN);
+		map.put(IntegerTerm.get(8), MetaType.EIGHT);
+		map.put(IntegerTerm.get(9), MetaType.NINE);
+		map.put(AtomTerm.get(":"), MetaType.COLON);
+		map.put(AtomTerm.get("^"), MetaType.EXISTS);
+	}
+
+	public enum MetaType
+	{
+		NORMAL, META, ONE, TWO, THREE, FOUR, FIVE, SIX, SEVEN, EIGHT, NINE, COLON, EXISTS;
+	}
+	public MetaType[] args = null;
+	public MetaPredicateInfo(MetaType[] args)
+	{
+		this.args = args;
+	}
+
+	/**
+	 *  Given a term, retrieve the appropriate meta value for it
+	 * @param t
+	 *   The term to look up
+	 * @throws PrologException
+	 *   if t does not correspond to a meta type
+	 */
+	public static MetaType get(Term t) throws PrologException
+	{
+		if (map.containsKey(t))
+			return map.get(t);
+		PrologException.domainError(AtomTerm.get("meta_argument_specifier"), t);
+		return MetaType.NORMAL; // Unreachable
+	}
+}

--- a/src/gnu/prolog/database/Module.java
+++ b/src/gnu/prolog/database/Module.java
@@ -100,11 +100,7 @@ public class Module
 			headArgs[i] = new VariableTerm();
 			if (metaPredicateInfo != null)
 			{
-				if (metaPredicateInfo.args[i] == MetaPredicateInfo.MetaType.META)
-				{
-					bodyArgs[i] = new CompoundTerm(AtomTerm.get(":"), new Term[]{name, headArgs[i]});
-				}
-				else if (metaPredicateInfo.args[i] == MetaPredicateInfo.MetaType.EXISTS)
+				if (metaPredicateInfo.args[i] == MetaPredicateInfo.MetaType.EXISTS)
 				{
 					// This means that it could be called with ^(Quantifiers, X) or X
 					// We want to substitute that for ^(Quantifiers, Module:X) or (Module:X), respectively
@@ -130,6 +126,10 @@ public class Module
 					{
 						body = new CompoundTerm(AtomTerm.get(","), new Term[]{determinant, body});
 					}
+				}
+				else if (metaPredicateInfo.args[i] != MetaPredicateInfo.MetaType.NORMAL)
+				{
+					bodyArgs[i] = new CompoundTerm(AtomTerm.get(":"), new Term[]{name, headArgs[i]});
 				}
 				else
 				{

--- a/src/gnu/prolog/database/Module.java
+++ b/src/gnu/prolog/database/Module.java
@@ -116,7 +116,7 @@ public class Module
 					// )
 					VariableTerm quantifier = new VariableTerm("Q");
 					VariableTerm goal = new VariableTerm("Goal");
-					VariableTerm outArg = new VariableTerm("outArg");
+					VariableTerm outArg = new VariableTerm("OutArg");
 					bodyArgs[i] = outArg;
 					Term determinant = new CompoundTerm(AtomTerm.get(";"), new Term[]{new CompoundTerm(AtomTerm.get("->"), new Term[]{new CompoundTerm(AtomTerm.get("="), new Term[]{headArgs[i], new CompoundTerm(AtomTerm.get("^"), new Term[]{quantifier, goal})}),
 																			  new CompoundTerm(AtomTerm.get("="), new Term[]{outArg, new CompoundTerm(AtomTerm.get("^"), new Term[]{quantifier, new CompoundTerm(AtomTerm.get(":"), new Term[]{name, goal})})})}),
@@ -150,6 +150,7 @@ public class Module
 		{
 			body = new CompoundTerm(AtomTerm.get(","), new Term[]{body, crossModuleCall(exportingModuleName.value, new CompoundTerm(export, bodyArgs))});
 		}
+
 		Term linkClause = new CompoundTerm(CompoundTermTag.get(":-", 2), new Term[]{head, body});
 		p.setType(Predicate.TYPE.USER_DEFINED);
 		p.addClauseLast(linkClause);

--- a/src/gnu/prolog/database/Module.java
+++ b/src/gnu/prolog/database/Module.java
@@ -79,7 +79,7 @@ public class Module
 	   }
 	}
 
-	public Predicate importPredicate(Environment environment, AtomTerm exportingModule, CompoundTermTag export) throws PrologException
+	public Predicate importPredicate(Environment environment, AtomTerm exportingModuleName, CompoundTermTag export) throws PrologException
 	{
 		Predicate p = null;
 		try
@@ -90,13 +90,26 @@ public class Module
 		{
 			PrologException.permissionError(AtomTerm.get("redefine"), AtomTerm.get("predicate"), export.getPredicateIndicator());
 		}
-		Term[] args = new Term[export.arity];
-		for (int i = 0; i < args.length; i++)
-			args[i] = new VariableTerm();
-		Term head = new CompoundTerm(export, args);
-		Term body = crossModuleCall(exportingModule.value, head);
-		Term linkClause = new CompoundTerm(CompoundTermTag.get(":-", 2), new Term[]{head, body});
-		p.setType(Predicate.TYPE.USER_DEFINED);
+                Term[] headArgs = new Term[export.arity];
+		Term[] bodyArgs = new Term[export.arity];
+		Module exportingModule = environment.getModule(exportingModuleName);
+		MetaPredicateInfo metaPredicateInfo = exportingModule.getMetaPredicateInfo(export);
+                for (int i = 0; i < export.arity; i++)
+                {
+			headArgs[i] = new VariableTerm();
+			if (metaPredicateInfo != null && metaPredicateInfo.args[i] == MetaPredicateInfo.MetaType.META)
+			{
+                                bodyArgs[i] = new CompoundTerm(AtomTerm.get(":"), new Term[]{name, headArgs[i]});
+                        }
+                        else
+                        {
+                                bodyArgs[i] = headArgs[i];
+                        }
+                }
+                Term head = new CompoundTerm(export, headArgs);
+		Term body = crossModuleCall(exportingModuleName.value, new CompoundTerm(export, bodyArgs));
+                Term linkClause = new CompoundTerm(CompoundTermTag.get(":-", 2), new Term[]{head, body});
+                p.setType(Predicate.TYPE.USER_DEFINED);
 		p.addClauseLast(linkClause);
 		environment.pushModule(name);
 		try
@@ -108,7 +121,7 @@ public class Module
 		{
 			environment.popModule();
 		}
-	}
+        }
 
 	/**
 	 * convenience method for getting a Module:Goal term
@@ -412,5 +425,15 @@ public class Module
 	public String toString()
 	{
 		return name.toString();
+	}
+
+	public MetaPredicateInfo getMetaPredicateInfo(CompoundTermTag tag)
+	{
+		Predicate p = tag2predicate.get(tag);
+		if (p == null)
+		{
+			return null;
+		}
+		return p.getMetaPredicateInfo();
 	}
 }

--- a/src/gnu/prolog/database/Predicate.java
+++ b/src/gnu/prolog/database/Predicate.java
@@ -77,12 +77,17 @@ public class Predicate
 	protected boolean propertiesLocked = false;
 	/** dynamic property of predicate */
 	protected boolean dynamicFlag = false;
+	/** meta property of predicate */
+	protected MetaPredicateInfo metaPredicateInfo = null;
 	/** class name for external predicate */
 	protected String javaClassName;
 	/** set files where this predicate is defined */
 	protected Set<String> files = new HashSet<String>();
 	/** current module */
 	protected Module module;
+	/** exporting module */
+	protected Module sourceModule;
+
 
 	/**
 	 * constructor of predicate
@@ -309,6 +314,21 @@ public class Predicate
 		dynamicFlag = true;
 	}
 
+	/**
+	 * set "meta" property of predicate to the given value. This method must be called
+	 * before the /goal/ is called, but can be called either before or after the predicate
+	 * has any clauses added to it
+	 */
+	public synchronized void setMeta(MetaPredicateInfo info)
+	{
+		metaPredicateInfo = info;
+	}
+
+	public synchronized MetaPredicateInfo getMetaPredicateInfo()
+	{
+		return metaPredicateInfo;
+	}
+
 	@Override
 	public synchronized String toString()
 	{
@@ -408,5 +428,15 @@ public class Predicate
 			PrologException.typeError(TermConstants.callableAtom, term);
 			return null;// never happens
 		}
+	}
+
+	public void setSourceModule(Module m)
+	{
+		sourceModule = m;
+	}
+
+	public Module getSourceModule()
+	{
+		return sourceModule;
 	}
 }

--- a/src/gnu/prolog/database/Predicate.java
+++ b/src/gnu/prolog/database/Predicate.java
@@ -77,6 +77,8 @@ public class Predicate
 	protected boolean propertiesLocked = false;
 	/** dynamic property of predicate */
 	protected boolean dynamicFlag = false;
+	/** meta property of predicate */
+	protected MetaPredicateInfo metaPredicateInfo = null;
 	/** class name for external predicate */
 	protected String javaClassName;
 	/** set files where this predicate is defined */
@@ -307,6 +309,21 @@ public class Predicate
 			throw new IllegalStateException("dynamic property of predicate could not be changed");
 		}
 		dynamicFlag = true;
+	}
+
+	/**
+	 * set "meta" property of predicate to the given value. This method must be called
+	 * before the /goal/ is called, but can be called either before or after the predicate
+	 * has any clauses added to it
+	 */
+	public synchronized void setMeta(MetaPredicateInfo info)
+	{
+		metaPredicateInfo = info;
+	}
+
+	public synchronized MetaPredicateInfo getMetaPredicateInfo()
+	{
+		return metaPredicateInfo;
 	}
 
 	@Override

--- a/src/gnu/prolog/database/PrologTextLoader.java
+++ b/src/gnu/prolog/database/PrologTextLoader.java
@@ -66,6 +66,7 @@ public class PrologTextLoader
 	public static final CompoundTermTag multifileTag = CompoundTermTag.get("multifile", 1);
 	public static final CompoundTermTag dynamicTag = CompoundTermTag.get("dynamic", 1);
 	public static final CompoundTermTag discontiguousTag = CompoundTermTag.get("discontiguous", 1);
+	public static final CompoundTermTag metaPredicateTag = CompoundTermTag.get("meta_predicate", 1);
 	public static final CompoundTermTag opTag = CompoundTermTag.get("op", 3);
 	public static final CompoundTermTag char_conversionTag = CompoundTermTag.get("char_conversion", 2);
 	public static final CompoundTermTag initializationTag = CompoundTermTag.get("initialization", 1);
@@ -242,6 +243,10 @@ public class PrologTextLoader
 					else if (dirTag == dynamicTag)
 					{
 						processDynamicDirective(dirTerm.args[0]);
+					}
+					else if (dirTag == metaPredicateTag)
+					{
+						processMetaPredicateDirective(dirTerm.args[0]);
 					}
 					else if (dirTag == discontiguousTag)
 					{
@@ -483,6 +488,33 @@ public class PrologTextLoader
 		// pi is a CompoundTerm as isPredicateIndicator checks that
 		CompoundTermTag tag = CompoundTermTag.get((CompoundTerm) pi);
 		prologTextLoaderState.declareDynamic(this, tag);
+	}
+
+	protected void processMetaPredicateDirective(Term mi)
+	{
+		if (!(mi instanceof CompoundTerm))
+		{
+			logError("the meta predicate indicator is not valid.");
+			return;
+		}
+		CompoundTerm directive = (CompoundTerm)mi;
+		CompoundTermTag tag = directive.tag;
+		MetaPredicateInfo.MetaType[] metaArgs = new MetaPredicateInfo.MetaType[tag.arity];
+		try
+		{
+			for (int i = 0; i < tag.arity; i++)
+			{
+				metaArgs[i] = MetaPredicateInfo.get(directive.args[i]);
+			}
+		}
+		catch(PrologException ex)
+		{
+			ex.printStackTrace();
+			logError("the predicate indicator is not valid.");
+			return;
+		}
+		MetaPredicateInfo info = new MetaPredicateInfo(metaArgs);
+		prologTextLoaderState.declareMeta(this, tag, info);
 	}
 
 	protected void processClause(Term argument)

--- a/src/gnu/prolog/database/PrologTextLoader.java
+++ b/src/gnu/prolog/database/PrologTextLoader.java
@@ -66,6 +66,7 @@ public class PrologTextLoader
 	public static final CompoundTermTag multifileTag = CompoundTermTag.get("multifile", 1);
 	public static final CompoundTermTag dynamicTag = CompoundTermTag.get("dynamic", 1);
 	public static final CompoundTermTag discontiguousTag = CompoundTermTag.get("discontiguous", 1);
+	public static final CompoundTermTag metaPredicateTag = CompoundTermTag.get("meta_predicate", 1);
 	public static final CompoundTermTag opTag = CompoundTermTag.get("op", 3);
 	public static final CompoundTermTag char_conversionTag = CompoundTermTag.get("char_conversion", 2);
 	public static final CompoundTermTag initializationTag = CompoundTermTag.get("initialization", 1);
@@ -242,6 +243,10 @@ public class PrologTextLoader
 					else if (dirTag == dynamicTag)
 					{
 						processDynamicDirective(dirTerm.args[0]);
+					}
+					else if (dirTag == metaPredicateTag)
+					{
+						processMetaPredicateDirective(dirTerm.args[0]);
 					}
 					else if (dirTag == discontiguousTag)
 					{
@@ -483,6 +488,33 @@ public class PrologTextLoader
 		// pi is a CompoundTerm as isPredicateIndicator checks that
 		CompoundTermTag tag = CompoundTermTag.get((CompoundTerm) pi);
 		prologTextLoaderState.declareDynamic(this, tag);
+	}
+
+	protected void processMetaPredicateDirective(Term mi)
+	{
+		if (!(mi instanceof CompoundTerm))
+		{
+			logError("the meta predicate indicator is not valid.");
+			return;
+		}
+		CompoundTerm directive = (CompoundTerm)mi;
+		CompoundTermTag tag = CompoundTermTag.get(directive);
+		MetaPredicateInfo.MetaType[] metaArgs = new MetaPredicateInfo.MetaType[tag.arity];
+		try
+		{
+			for (int i = 0; i < tag.arity; i++)
+			{
+				metaArgs[i] = MetaPredicateInfo.get(directive.args[i]);
+			}
+		}
+		catch(PrologException ex)
+		{
+			ex.printStackTrace();
+			logError("the predicate indicator is not valid.");
+			return;
+		}
+		MetaPredicateInfo info = new MetaPredicateInfo(metaArgs);
+		prologTextLoaderState.declareMeta(this, tag, info);
 	}
 
 	protected void processClause(Term argument)

--- a/src/gnu/prolog/database/PrologTextLoaderState.java
+++ b/src/gnu/prolog/database/PrologTextLoaderState.java
@@ -226,6 +226,17 @@ public class PrologTextLoaderState implements PrologTextLoaderListener, HasEnvir
 		return true;
 	}
 
+	public boolean declareMeta(PrologTextLoader loader, CompoundTermTag tag, MetaPredicateInfo info)
+	{
+		Predicate p = module.getOrCreateDefinedPredicate(tag);
+		if (p.getType() == Predicate.TYPE.UNDEFINED)
+		{
+			p.setType(Predicate.TYPE.USER_DEFINED);
+		}
+		p.setMeta(info);
+		return true;
+	}
+
 	public void declareMultifile(PrologTextLoader loader, CompoundTermTag tag)
 	{
 		Predicate p = module.getOrCreateDefinedPredicate(tag);

--- a/src/gnu/prolog/vm/Environment.java
+++ b/src/gnu/prolog/vm/Environment.java
@@ -406,6 +406,11 @@ public class Environment implements PredicateListener
 		return modules.get(moduleStack.peek());
 	}
 
+	public Module getModule(AtomTerm name)
+	{
+		return modules.get(name);
+	}
+
 	/**
 	 * load code for prolog
 	 * 
@@ -435,8 +440,8 @@ public class Environment implements PredicateListener
 					// Otherwise when we call Goal in user, the module will still be the current module. If both user and the local module
 					// both define a clause of something, when the user module calls it, we will get the one in the current module, which
 					// is wrong!
-					p = getModule().importPredicate(this, Module.userAtom, tag);
-
+					Module sourceModule = p.getSourceModule();
+					p = getModule().importPredicate(this, (sourceModule==null?Module.userAtom:sourceModule.getName()), tag);
 				}
 				// At this point we can fall back to the switch statement below
 			}

--- a/src/gnu/prolog/vm/Environment.java
+++ b/src/gnu/prolog/vm/Environment.java
@@ -463,6 +463,10 @@ public class Environment implements PredicateListener
 					Class<?> cls = Class.forName(p.getJavaClassName());
 					PrologCode code = (PrologCode) cls.newInstance();
 					code.install(this);
+					if (code instanceof ExecuteOnlyMetaCode)
+					{
+						p.setMeta(((ExecuteOnlyMetaCode)code).getMetaPredicateInfo());
+					}
 					return code;
 				}
 				catch (/* ClassNotFound */Exception ex)

--- a/src/gnu/prolog/vm/Environment.java
+++ b/src/gnu/prolog/vm/Environment.java
@@ -406,6 +406,11 @@ public class Environment implements PredicateListener
 		return modules.get(moduleStack.peek());
 	}
 
+	public Module getModule(AtomTerm name)
+	{
+		return modules.get(name);
+	}
+
 	/**
 	 * load code for prolog
 	 * 

--- a/src/gnu/prolog/vm/ExecuteOnlyMetaCode.java
+++ b/src/gnu/prolog/vm/ExecuteOnlyMetaCode.java
@@ -1,0 +1,37 @@
+/* GNU Prolog for Java
+ * Copyright (C) 2010       Daniel Thomas
+ * Copyright (C) 2016       Matt Lilley
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA  02111-1307, USA. The text of license can be also found 
+ * at http://www.gnu.org/copyleft/lgpl.html
+ */
+package gnu.prolog.vm;
+
+import gnu.prolog.database.MetaPredicateInfo;
+
+/**
+ * For built-in predicates with meta-arg-information
+ * 
+ * @author Matt Lilley
+ */
+public abstract class ExecuteOnlyMetaCode extends ExecuteOnlyCode
+{
+
+	public abstract RC execute(Interpreter interpreter, boolean backtrackMode, gnu.prolog.term.Term args[])
+			throws PrologException;
+
+
+	public abstract MetaPredicateInfo getMetaPredicateInfo();
+}

--- a/src/gnu/prolog/vm/buildins/allsolutions/Predicate_bagof.java
+++ b/src/gnu/prolog/vm/buildins/allsolutions/Predicate_bagof.java
@@ -17,12 +17,13 @@
  */
 package gnu.prolog.vm.buildins.allsolutions;
 
+import gnu.prolog.database.MetaPredicateInfo;
 import gnu.prolog.term.CompoundTerm;
 import gnu.prolog.term.CompoundTermTag;
 import gnu.prolog.term.Term;
 import gnu.prolog.term.TermUtils;
 import gnu.prolog.vm.BacktrackInfo;
-import gnu.prolog.vm.ExecuteOnlyCode;
+import gnu.prolog.vm.ExecuteOnlyMetaCode;
 import gnu.prolog.vm.Interpreter;
 import gnu.prolog.vm.PrologException;
 
@@ -35,7 +36,7 @@ import java.util.Set;
 /**
  * prolog code
  */
-public class Predicate_bagof extends ExecuteOnlyCode
+public class Predicate_bagof extends ExecuteOnlyMetaCode
 {
 	static final CompoundTermTag plusTag = CompoundTermTag.get("+", 2);
 
@@ -139,5 +140,13 @@ public class Predicate_bagof extends ExecuteOnlyCode
 
 	protected void processList(List<Term> curTList)
 	{}
+
+	private static MetaPredicateInfo metaPredicateInfo = new MetaPredicateInfo(new MetaPredicateInfo.MetaType[]{MetaPredicateInfo.MetaType.NORMAL,
+														    MetaPredicateInfo.MetaType.META,
+														    MetaPredicateInfo.MetaType.NORMAL});
+	public MetaPredicateInfo getMetaPredicateInfo()
+	{
+		return metaPredicateInfo;
+	}
 
 }

--- a/src/gnu/prolog/vm/buildins/allsolutions/Predicate_bagof.java
+++ b/src/gnu/prolog/vm/buildins/allsolutions/Predicate_bagof.java
@@ -142,7 +142,7 @@ public class Predicate_bagof extends ExecuteOnlyMetaCode
 	{}
 
 	private static MetaPredicateInfo metaPredicateInfo = new MetaPredicateInfo(new MetaPredicateInfo.MetaType[]{MetaPredicateInfo.MetaType.NORMAL,
-														    MetaPredicateInfo.MetaType.META,
+														    MetaPredicateInfo.MetaType.EXISTS,
 														    MetaPredicateInfo.MetaType.NORMAL});
 	public MetaPredicateInfo getMetaPredicateInfo()
 	{

--- a/src/gnu/prolog/vm/buildins/allsolutions/Predicate_findall.java
+++ b/src/gnu/prolog/vm/buildins/allsolutions/Predicate_findall.java
@@ -17,11 +17,12 @@
  */
 package gnu.prolog.vm.buildins.allsolutions;
 
+import gnu.prolog.database.MetaPredicateInfo;
 import gnu.prolog.term.CompoundTerm;
 import gnu.prolog.term.Term;
 import gnu.prolog.term.VariableTerm;
 import gnu.prolog.vm.BacktrackInfo;
-import gnu.prolog.vm.ExecuteOnlyCode;
+import gnu.prolog.vm.ExecuteOnlyMetaCode;
 import gnu.prolog.vm.Interpreter;
 import gnu.prolog.vm.PrologCode;
 import gnu.prolog.vm.PrologException;
@@ -34,7 +35,7 @@ import java.util.List;
 /**
  * prolog code
  */
-public class Predicate_findall extends ExecuteOnlyCode
+public class Predicate_findall extends ExecuteOnlyMetaCode
 {
 	@Override
 	public RC execute(Interpreter interpreter, boolean backtrackMode, gnu.prolog.term.Term args[]) throws PrologException
@@ -132,4 +133,14 @@ public class Predicate_findall extends ExecuteOnlyCode
 			list = ct.args[1].dereference();
 		}
 	}
+
+	private static MetaPredicateInfo metaPredicateInfo = new MetaPredicateInfo(new MetaPredicateInfo.MetaType[]{MetaPredicateInfo.MetaType.NORMAL,
+														    MetaPredicateInfo.MetaType.META,
+														    MetaPredicateInfo.MetaType.NORMAL});
+	public MetaPredicateInfo getMetaPredicateInfo()
+	{
+		return metaPredicateInfo;
+	}
+
+
 }

--- a/src/gnu/prolog/vm/buildins/buildins.pro
+++ b/src/gnu/prolog/vm/buildins/buildins.pro
@@ -191,7 +191,9 @@ write_canonical(S,Term):-write_term(S,Term,[quoted(true),ignore_ops(true)]).
 '\\+'(Goal) :- call(Goal),!,fail.
 '\\+'(Goal).
 
+:-meta_predicate(not(0)).
 not(Goal) :- '\\+'(Goal).
+:-meta_predicate(fail_if(0)).
 fail_if(Goal) :- '\\+'(Goal).
 
 :-meta_predicate(once(0)).

--- a/src/gnu/prolog/vm/buildins/buildins.pro
+++ b/src/gnu/prolog/vm/buildins/buildins.pro
@@ -194,6 +194,7 @@ write_canonical(S,Term):-write_term(S,Term,[quoted(true),ignore_ops(true)]).
 not(Goal) :- '\\+'(Goal).
 fail_if(Goal) :- '\\+'(Goal).
 
+:-meta_predicate(once(0)).
 once(Goal) :- call(Goal),!.
 
 repeat.

--- a/src/gnu/prolog/vm/buildins/buildins.pro
+++ b/src/gnu/prolog/vm/buildins/buildins.pro
@@ -187,6 +187,7 @@ write_canonical(S,Term):-write_term(S,Term,[quoted(true),ignore_ops(true)]).
 
 % 8.15 logic and control
 
+:-meta_predicate('\\+'(0)).
 '\\+'(Goal) :- call(Goal),!,fail.
 '\\+'(Goal).
 

--- a/src/gnu/prolog/vm/buildins/meta/Predicate_colon.java
+++ b/src/gnu/prolog/vm/buildins/meta/Predicate_colon.java
@@ -61,8 +61,7 @@ public class Predicate_colon extends ExecuteOnlyCode
 			if (rc == RC.SUCCESS)
 			{
 				// Make a fake backtrack point here so we get a chance to restore the module context if backtracking
-				if (bi == null)
-					bi = new BacktrackInfo(interpreter.getUndoPosition(), -1);
+                                bi = new BacktrackInfo(interpreter.getUndoPosition(), -1);
 				interpreter.pushBacktrackInfo(bi);
 			}
 		}

--- a/src/gnu/prolog/vm/buildins/meta/Predicate_setup_call_catcher_cleanup.java
+++ b/src/gnu/prolog/vm/buildins/meta/Predicate_setup_call_catcher_cleanup.java
@@ -19,12 +19,13 @@
 
 package gnu.prolog.vm.buildins.meta;
 
+import gnu.prolog.database.MetaPredicateInfo;
 import gnu.prolog.term.AtomTerm;
 import gnu.prolog.term.CompoundTerm;
 import gnu.prolog.term.CompoundTermTag;
 import gnu.prolog.term.Term;
 import gnu.prolog.vm.BacktrackInfoWithCleanup;
-import gnu.prolog.vm.ExecuteOnlyCode;
+import gnu.prolog.vm.ExecuteOnlyMetaCode;
 import gnu.prolog.vm.Interpreter;
 import gnu.prolog.vm.PrologException;
 import gnu.prolog.vm.BacktrackInfo;
@@ -35,7 +36,7 @@ import gnu.prolog.vm.interpreter.Predicate_call;
  * 
  */
 
-public class Predicate_setup_call_catcher_cleanup extends ExecuteOnlyCode
+public class Predicate_setup_call_catcher_cleanup extends ExecuteOnlyMetaCode
 {
 	@Override
 	public RC execute(Interpreter interpreter, boolean backtrackMode, gnu.prolog.term.Term args[]) throws PrologException
@@ -145,6 +146,15 @@ public class Predicate_setup_call_catcher_cleanup extends ExecuteOnlyCode
 			}
 		}
 
+	}
+
+private static MetaPredicateInfo metaPredicateInfo = new MetaPredicateInfo(new MetaPredicateInfo.MetaType[]{MetaPredicateInfo.MetaType.META,
+													    MetaPredicateInfo.MetaType.META,
+													    MetaPredicateInfo.MetaType.NORMAL,
+													    MetaPredicateInfo.MetaType.META});
+	public MetaPredicateInfo getMetaPredicateInfo()
+	{
+		return metaPredicateInfo;
 	}
 
 }

--- a/src/gnu/prolog/vm/interpreter/Predicate_call.java
+++ b/src/gnu/prolog/vm/interpreter/Predicate_call.java
@@ -18,6 +18,7 @@
  */
 package gnu.prolog.vm.interpreter;
 
+import gnu.prolog.database.MetaPredicateInfo;
 import gnu.prolog.term.AtomTerm;
 import gnu.prolog.term.CompoundTerm;
 import gnu.prolog.term.Term;
@@ -25,7 +26,7 @@ import gnu.prolog.term.VariableTerm;
 import gnu.prolog.vm.BacktrackInfo;
 import gnu.prolog.vm.BacktrackInfoWithCleanup;
 import gnu.prolog.vm.Environment;
-import gnu.prolog.vm.ExecuteOnlyCode;
+import gnu.prolog.vm.ExecuteOnlyMetaCode;
 import gnu.prolog.vm.Interpreter;
 import gnu.prolog.vm.PrologCode;
 import gnu.prolog.vm.PrologException;
@@ -39,7 +40,7 @@ import java.util.Map;
 /**
  * prolog code
  */
-public class Predicate_call extends ExecuteOnlyCode
+public class Predicate_call extends ExecuteOnlyMetaCode
 {
 	/** head functor, it is completly unimportant what it is */
 	public static final AtomTerm headFunctor = AtomTerm.get("$$$call$$$");
@@ -219,4 +220,11 @@ public class Predicate_call extends ExecuteOnlyCode
 			throw new IllegalArgumentException("the term is not callable");
 		}
 	}
+
+	private static MetaPredicateInfo metaPredicateInfo = new MetaPredicateInfo(new MetaPredicateInfo.MetaType[]{MetaPredicateInfo.MetaType.META});
+	public MetaPredicateInfo getMetaPredicateInfo()
+	{
+		return metaPredicateInfo;
+	}
+
 }

--- a/test/extending/modules/test_metapredicate_after.pl
+++ b/test/extending/modules/test_metapredicate_after.pl
@@ -1,0 +1,33 @@
+:-module(a, [test/1]).
+
+test(X):-
+	a_meta_predicate(bar, A, goal(A), X).
+
+goal(w).
+goal(x).
+goal(y).
+
+goal.
+
+goal(a, w).
+goal(a, b).
+
+%a_meta_predicate(foo, _, _, wrong).
+
+:-module(b, [a_meta_predicate/4]).
+
+a_meta_predicate(bar, Template, Goal, X):-
+	b_predicate,
+	findall(Template, Goal, X).
+
+:-meta_predicate(a_meta_predicate(?, ?, 0, ?)).
+
+goal(wrong).
+goal(wrong).
+goal(wrong).
+goal.
+
+goal(wrong, wrong).
+goal(wrong, wrong).
+
+b_predicate.

--- a/test/extending/modules/test_metapredicate_before.pl
+++ b/test/extending/modules/test_metapredicate_before.pl
@@ -1,0 +1,33 @@
+:-module(a, [test/1]).
+
+test(X):-
+	a_meta_predicate(bar, A, goal(A), X).
+
+goal(w).
+goal(x).
+goal(y).
+
+goal.
+
+goal(a, w).
+goal(a, b).
+
+%a_meta_predicate(foo, _, _, wrong).
+
+:-module(b, [a_meta_predicate/4]).
+
+:-meta_predicate(a_meta_predicate(?, ?, 0, ?)).
+
+a_meta_predicate(bar, Template, Goal, X):-
+	b_predicate,
+	findall(Template, Goal, X).
+
+goal(wrong).
+goal(wrong).
+goal(wrong).
+goal.
+
+goal(wrong, wrong).
+goal(wrong, wrong).
+
+b_predicate.

--- a/test/extending/modules/test_metapredicate_missing.pl
+++ b/test/extending/modules/test_metapredicate_missing.pl
@@ -1,0 +1,31 @@
+:-module(a, [test/1]).
+
+test(X):-
+	a_meta_predicate(bar, A, goal(A), X).
+
+goal(w).
+goal(x).
+goal(y).
+
+goal.
+
+goal(a, w).
+goal(a, b).
+
+%a_meta_predicate(foo, _, _, wrong).
+
+:-module(b, [a_meta_predicate/4]).
+
+a_meta_predicate(bar, Template, Goal, X):-
+	b_predicate,
+	findall(Template, Goal, X).
+
+goal(wrong).
+goal(wrong).
+goal(wrong).
+goal.
+
+goal(wrong, wrong).
+goal(wrong, wrong).
+
+b_predicate.

--- a/test/extending/modules/test_module_a.pl
+++ b/test/extending/modules/test_module_a.pl
@@ -17,4 +17,13 @@ local_predicate:-
 
 % This is a weak override for the one in user
 predicate_with_choicepoint(X):-
-	member(X, [a,b,c]).
+        member(X, [a,b,c]).
+
+
+issue_14(a).
+issue_14(b).
+issue_14(c).
+issue_14(X):- b:issue_14(X).
+issue_14(d).
+issue_14(e).
+issue_14(f).

--- a/test/extending/modules/test_module_b.pl
+++ b/test/extending/modules/test_module_b.pl
@@ -6,3 +6,7 @@ predicate_exported_from_b:-
 
 local_predicate:-
 	write('>b:local_predicate'), nl.
+
+issue_14(x).
+issue_14(y).
+issue_14(z).

--- a/test/extending/modules/test_with_modules.pl
+++ b/test/extending/modules/test_with_modules.pl
@@ -20,7 +20,14 @@ test:-
 	;  write('FAIL: predicate_exported_from_c should not exist'), nl
 	),
 	% Explicitly call a goal in another module
-	c:local_predicate.
+        c:local_predicate,
+        % Test for issue #14
+        issue_14.
+
+
+issue_14:-
+        findall(X, a:issue_14(X), Xs),
+        Xs == [a,b,c,x,y,z,d,e,f].
 
 local_predicate:-
 	write('>predicate_in_user'), nl.


### PR DESCRIPTION
This addresses #16 

This probably needs some documentation too, but I'm not sure where to put it. There are some tests included.

If you're not familiar with the meta-predicate problem, then http://yfl.bahmanm.com/Members/ttmrichter/yfl-blog/meta-predicates-in-swi-prolog does a pretty good job of explaining it. I independently arrived at exactly the same solution by discovering exactly the same pitfalls, which is encouraging.

I've created a new class ExecuteOnlyMetaCode which extends ExecuteOnlyCode but provides a method to get meta-predicate information. This isn't very pretty, but I wanted to make sure that when installing predicates from Java directly that we had some way for the predicates to indicate their meta-args directly.

Note that there are only 3 classes of meta-arg we care about: quantified (^), normal(+, -, ?) and everything-else. No distinction is made between 3 and :, for example.
