### PR TITLE
Disable doclint and tidy up a few actual pldoc mistakes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -191,7 +191,8 @@ Ant Buildfile for GNU Prolog for Java.
 	<target name="doc" depends="init,manual" description="Make the javadoc api and copy the demo applications">
 		<mkdir dir="build/api" />
 		<javadoc sourcepath="src" destdir="build/api" version="yes" author="yes"
-			use="yes" classpath="${java.class.path}:/usr/share/java/gnu-getopt.jar">
+			 use="yes" classpath="${java.class.path}:/usr/share/java/gnu-getopt.jar">
+		  <arg value="-Xdoclint:none"/>
 			<packageset dir="src">
 				<include name="gnu/prolog/**" />
 			</packageset>

--- a/src/gnu/prolog/io/parser/package-info.java
+++ b/src/gnu/prolog/io/parser/package-info.java
@@ -10,9 +10,9 @@
  * in ANTLR 4 but ANTLR 4 does not support left-recursion with parameters
  * 
  * This package also contains classes such as
- * {@link gnu.prolog.io.parser.NameToken NameToken},
- * {@link gnu.prolog.io.parser.JavaCharStream JavaCharStream} and
- * {@link gnu.prolog.io.parser.TermParserUtils TermParserUtils} which contain
+ * {@link gnu.prolog.io.parser.NameToken},
+ * {@link gnu.prolog.io.parser.TokenFactory} and
+ * {@link gnu.prolog.io.parser.TermParserUtils} which contain
  * some of the code needed to integrate the generated parser with the rest of
  * the codebase.
  * 

--- a/src/gnu/prolog/vm/buildins/allsolutions/Predicate_findall.java
+++ b/src/gnu/prolog/vm/buildins/allsolutions/Predicate_findall.java
@@ -58,8 +58,8 @@ public class Predicate_findall extends ExecuteOnlyCode
 	 * @param template
 	 * @param goal
 	 * @param list
-	 * @return either {@link PrologCode.RC#SUCCESS_LAST} or
-	 *         {@link PrologCode.RC#FAIL}
+	 * @return either {@link gnu.prolog.vm.PrologCode.RC#SUCCESS_LAST} or
+	 *                {@link gnu.prolog.vm.PrologCode.RC#FAIL}
 	 * @throws PrologException
 	 */
 	public static RC findall(Interpreter interpreter, boolean backtrackMode, Term template, Term goal, List<Term> list)

--- a/src/gnu/prolog/vm/interpreter/Predicate_call.java
+++ b/src/gnu/prolog/vm/interpreter/Predicate_call.java
@@ -171,7 +171,7 @@ public class Predicate_call extends ExecuteOnlyCode
 	 * 
 	 * @param term
 	 * @param argumentsToArgumentVariables
-	 * @return
+	 * @return clause generated from term
 	 */
 	public static Term getClause(Term term, Map<Term, VariableTerm> argumentsToArgumentVariables)
 	{


### PR DESCRIPTION
This addresses #20 which seems to only report all those warnings on java-1.8+ due to doclint being enabled by default
