### PR TITLE
Provide a method for printing arbitrary terms

### DIFF
--- a/src/gnu/prolog/io/TermWriter.java
+++ b/src/gnu/prolog/io/TermWriter.java
@@ -18,6 +18,7 @@
  */
 package gnu.prolog.io;
 
+import gnu.prolog.term.AtomicTerm;
 import gnu.prolog.term.AtomTerm;
 import gnu.prolog.term.CompoundTerm;
 import gnu.prolog.term.CompoundTermTag;
@@ -210,6 +211,10 @@ public class TermWriter extends PrintWriter
 		else if (term instanceof JavaObjectTerm)
 		{
 			displayJavaObject(options, (JavaObjectTerm) term);
+		}
+		else if (term instanceof AtomicTerm)
+		{
+			((AtomicTerm)term).displayTerm(options, this);
 		}
 	}
 

--- a/src/gnu/prolog/term/AtomicTerm.java
+++ b/src/gnu/prolog/term/AtomicTerm.java
@@ -17,6 +17,9 @@
  */
 package gnu.prolog.term;
 
+import gnu.prolog.io.TermWriter;
+import gnu.prolog.io.WriteOptions;
+
 /**
  * base class for all constant terms
  * 
@@ -37,6 +40,23 @@ public abstract class AtomicTerm extends Term
 	public Object clone()
 	{
 		return this;
+	}
+
+	/**
+	 * You can override this to control printing of terms
+	 * that derive from AtomicTerm that are not otherwise built-in
+	 * If the default implementation below is used, a term will be
+	 * printed that cannot be read back. This is by design, to
+	 * highlight the problem that the method is not implemented in
+	 * the subclass
+	 * @param options
+	 *          WriteOptions to use
+	 * @param writer
+	 *          TermWriter to write the term to
+	 */
+	public void displayTerm(WriteOptions options, TermWriter writer)
+	{
+		writer.print("<unprintable>");
 	}
 
 }


### PR DESCRIPTION
This is for issue #24. Possibly this should actually be an abstract method, and AtomTerm, IntegerTerm, and all the rest of them should provide their own implementations, rather than having a large if-then-else involving instanceof operators in TermWriter directly. If you'd like to do that, I suggest you merge this first, then file another issue to track the refactoring
