### PR TITLE
Fix issue 28 and add a test case for sign()

### DIFF
--- a/src/gnu/prolog/vm/Evaluate.java
+++ b/src/gnu/prolog/vm/Evaluate.java
@@ -764,12 +764,12 @@ public class Evaluate
 				if (arg0 instanceof IntegerTerm)
 				{
 					IntegerTerm i0 = (IntegerTerm) arg0;
-					return IntegerTerm.get(i0.value >= 0 ? 1 : -1);
+                                        return IntegerTerm.get((int)Math.signum(i0.value));
 				}
 				else if (arg0 instanceof FloatTerm)
 				{
 					FloatTerm f0 = (FloatTerm) arg0;
-					double res = f0.value >= 0 ? 1 : -1;
+                                        double res = Math.signum(f0.value);
 					return new FloatTerm(res);
 				}
 				else if (arg0 instanceof BigIntegerTerm)

--- a/test/inriasuite/arith/arith_sign
+++ b/test/inriasuite/arith/arith_sign
@@ -1,0 +1,12 @@
+/* file sign */
+
+[X is sign(0), [[X <-- 0]]].
+[X is sign(1), [[X <-- 1]]].
+[X is sign(-1), [[X <-- -1]]].
+[X is sign(3), [[X <-- 1]]].
+[X is sign(-3), [[X <-- -1]]].
+[X is sign(3.1), [[X <-- 1.0]]].
+[X is sign(-3.1), [[X <-- -1.0]]].
+
+/* end of sign */
+

--- a/test/inriasuite/inriasuite.pl
+++ b/test/inriasuite/inriasuite.pl
@@ -790,6 +790,7 @@ arith('arith_lt=').
 arith(arith_plus_minus).
 arith(arith_multiply_divide).
 arith(arith_elementary_operations).
+arith(arith_sign).
 
 %terms
 terms(term_diff).


### PR DESCRIPTION
I think this is just an oversight; sign() should return 0 if given 0 as an input. Math.signum() does the job. #28 